### PR TITLE
Updated loading plot from IMDB

### DIFF
--- a/lib/plugins/movie/PluginMovieIMDB-de.py
+++ b/lib/plugins/movie/PluginMovieIMDB-de.py
@@ -30,7 +30,7 @@ plugin_url          = 'www.imdb.de'
 plugin_language     = _('German')
 plugin_author       = 'Michael Jahn'
 plugin_author_email = 'mikej06@hotmail.com'
-plugin_version      = '1.9'
+plugin_version      = '1.10'
 
 class Plugin(movie.Movie):
     def __init__(self, id):
@@ -103,6 +103,14 @@ class Plugin(movie.Movie):
                 for element in elements:
                     if element <> '':
                         self.plot = self.plot + gutils.strip_tags(gutils.before(gutils.after(element, '>'), '</a>')) + '\n\n'
+        plotlist = string.split(gutils.trim(self.plot_page, 'id="plot-summaries-content">', '</ul>'), '<li')
+        plotcompilation = ''
+        for listelement in plotlist:
+            if listelement <> '':
+                plotcompilation = plotcompilation + gutils.trim(listelement, '<p>', '</p>') + '\n'
+                plotcompilation = plotcompilation + re.sub('<[^<]+?>', '', gutils.trim(listelement, '<div class="author-container">', '</div>').replace('\n','').lstrip()) + '\n\n'
+        if plotcompilation <> '':
+            self.plot = plotcompilation
 
     def get_year(self):
         self.year = gutils.trim(self.page, 'href="/year/', '/')

--- a/lib/plugins/movie/PluginMovieIMDB.py
+++ b/lib/plugins/movie/PluginMovieIMDB.py
@@ -30,7 +30,7 @@ plugin_url          = 'www.imdb.com'
 plugin_language     = _('English')
 plugin_author       = 'Vasco Nunes, Piotr Ożarowski'
 plugin_author_email = 'griffith@griffith.cc'
-plugin_version      = '1.15'
+plugin_version      = '1.16'
 
 class Plugin(movie.Movie):
     def __init__(self, id):
@@ -85,6 +85,14 @@ class Plugin(movie.Movie):
             for element in elements[1:]:
                 if element <> '':
                     self.plot = self.plot + gutils.strip_tags(gutils.before(element, '</a>')) + '\n\n'
+        plotlist = string.split(gutils.trim(self.plot_page, 'id="plot-summaries-content">', '</ul>'), '<li')
+        plotcompilation = ''
+        for listelement in plotlist:
+            if listelement <> '':
+                plotcompilation = plotcompilation + gutils.trim(listelement, '<p>', '</p>') + '\n'
+                plotcompilation = plotcompilation + re.sub('<[^<]+?>', '', gutils.trim(listelement, '<div class="author-container">', '</div>').replace('\n','').lstrip()) + '\n\n'
+        if plotcompilation <> '':
+            self.plot = plotcompilation
 
     def get_year(self):
         self.year = gutils.trim(self.page, '<a href="/year/', '</a>')


### PR DESCRIPTION
Related to Launchpad Bug #1721640: "Movie Plot/Summary not populating well". See https://bugs.launchpad.net/griffith/+bug/1721640.
The original code didn't find any plot-related text, because the class "plotSummary" is gone on the plotsummary page. So the plot from the main movie page was provided. I created this as a kind of "fallback". If it can find the plot with id="plot-summaries-content" on the plotsummary page, it will try to harvest all descriptions found there and provide this as plot. Else the plot from the main page succeedes.
I have also implemented this for IMDB-de, because the content is almost the same. Maybe we should consider to consolidate these language dependent import filters for IMDB? Some more investigation on this is needed.